### PR TITLE
Add JWT signup/login routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ frontend/    React application (components, pages)
 
 The backend exposes an `/api/users` endpoint that queries a `users` table from PostgreSQL. Edit the database credentials in `backend/src/config/db.js` to match your environment.
 
+Additional authentication routes are available:
+
+- `POST /api/signup` – create an account (roles: `speaker`, `subscriber`, or `admin`).
+- `POST /api/login` – obtain a JWT for authenticated requests.
+
 ### Frontend
 
 The React frontend fetches users from the API and renders them. Run the frontend and backend separately or behind a proxy. Both projects have their own `package.json` with typical npm scripts.

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "express": "^4.18.0",
-    "pg": "^8.10.0"
+    "pg": "^8.10.0",
+    "bcrypt": "^6.0.0",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "nodemon": "^2.0.0"

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,4 +1,8 @@
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
 const UserModel = require('../models/userModel');
+
+const allowedRoles = ['speaker', 'subscriber', 'admin'];
 
 const UserController = {
   async list(req, res) {
@@ -8,6 +12,55 @@ const UserController = {
     } catch (err) {
       console.error(err);
       res.status(500).json({ error: 'Failed to fetch users' });
+    }
+  },
+
+  async signup(req, res) {
+    try {
+      const { name, email, password, role } = req.body;
+      if (!name || !email || !password) {
+        return res.status(400).json({ error: 'Name, email and password are required' });
+      }
+
+      const existing = await UserModel.findByEmail(email);
+      if (existing) {
+        return res.status(409).json({ error: 'User already exists' });
+      }
+
+      const userRole = allowedRoles.includes(role) ? role : 'subscriber';
+      const hashed = await bcrypt.hash(password, 10);
+      const user = await UserModel.createUser({ name, email, password: hashed, role: userRole });
+
+      const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+      res.status(201).json({ token });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Signup failed' });
+    }
+  },
+
+  async login(req, res) {
+    try {
+      const { email, password } = req.body;
+      if (!email || !password) {
+        return res.status(400).json({ error: 'Email and password are required' });
+      }
+
+      const user = await UserModel.findByEmail(email);
+      if (!user) {
+        return res.status(401).json({ error: 'Invalid credentials' });
+      }
+
+      const valid = await bcrypt.compare(password, user.password);
+      if (!valid) {
+        return res.status(401).json({ error: 'Invalid credentials' });
+      }
+
+      const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+      res.json({ token });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Login failed' });
     }
   },
 };

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -2,8 +2,21 @@ const pool = require('../config/db');
 
 const UserModel = {
   async getAllUsers() {
-    const result = await pool.query('SELECT id, name FROM users');
+    const result = await pool.query('SELECT id, name, role FROM users');
     return result.rows;
+  },
+
+  async createUser({ name, email, password, role }) {
+    const result = await pool.query(
+      'INSERT INTO users (name, email, password, role) VALUES ($1, $2, $3, $4) RETURNING id, name, email, role',
+      [name, email, password, role]
+    );
+    return result.rows[0];
+  },
+
+  async findByEmail(email) {
+    const result = await pool.query('SELECT * FROM users WHERE email = $1', [email]);
+    return result.rows[0];
   },
 };
 

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -3,5 +3,7 @@ const router = express.Router();
 const UserController = require('../controllers/userController');
 
 router.get('/users', UserController.list);
+router.post('/signup', UserController.signup);
+router.post('/login', UserController.login);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add signup/login endpoints with JWT auth
- hash passwords and store user role
- document new endpoints in README

## Testing
- `npm test` *(fails: Missing script)*
- `(cd backend && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684b0244b9408321b7b55b0cb6e30a7b