### PR TITLE
Add role-based authorization middleware

### DIFF
--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -1,0 +1,24 @@
+const jwt = require('jsonwebtoken');
+
+function authorizeRoles(...allowed) {
+  return (req, res, next) => {
+    try {
+      const header = req.headers.authorization;
+      if (!header || !header.startsWith('Bearer ')) {
+        return res.status(401).json({ error: 'Missing authorization token' });
+      }
+      const token = header.slice(7);
+      const payload = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+      if (!allowed.includes(payload.role)) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      req.user = payload;
+      next();
+    } catch (err) {
+      console.error(err);
+      res.status(401).json({ error: 'Invalid or expired token' });
+    }
+  };
+}
+
+module.exports = authorizeRoles;

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const UserController = require('../controllers/userController');
+const authorizeRoles = require('../middleware/authMiddleware');
 
-router.get('/users', UserController.list);
+// Only admins can list all users
+router.get('/users', authorizeRoles('admin'), UserController.list);
 router.post('/signup', UserController.signup);
 router.post('/login', UserController.login);
 


### PR DESCRIPTION
## Summary
- add `authMiddleware` to validate JWT and check allowed roles
- use `authorizeRoles` middleware for `/api/users` route to restrict listing users to admins only

## Testing
- `node -v`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_b_684b062531308321acd0f71f20f5c212