### PR TITLE
Add speaker profile API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Additional authentication routes are available:
 
 - `POST /api/signup` – create an account (roles: `speaker`, `subscriber`, or `admin`).
 - `POST /api/login` – obtain a JWT for authenticated requests.
+- `GET /api/speakers` – list all speaker profiles.
+- `POST /api/speakers` – create a speaker profile (admin only).
+- `GET /api/speakers/:id` – fetch a single speaker profile.
+- `PUT /api/speakers/:id` – update a speaker profile (admin only).
+- `DELETE /api/speakers/:id` – remove a speaker profile (admin only).
 
 ### Frontend
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const userRoutes = require('./routes/userRoutes');
+const speakerRoutes = require('./routes/speakerRoutes');
 
 const app = express();
 
 app.use(express.json());
 
 app.use('/api', userRoutes);
+app.use('/api', speakerRoutes);
 
 module.exports = app;

--- a/backend/src/controllers/speakerController.js
+++ b/backend/src/controllers/speakerController.js
@@ -1,0 +1,66 @@
+const SpeakerModel = require('../models/speakerModel');
+
+const SpeakerController = {
+  async list(req, res) {
+    try {
+      const speakers = await SpeakerModel.getAllSpeakers();
+      res.json(speakers);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to fetch speakers' });
+    }
+  },
+
+  async getById(req, res) {
+    try {
+      const speaker = await SpeakerModel.getSpeakerById(req.params.id);
+      if (!speaker) {
+        return res.status(404).json({ error: 'Speaker not found' });
+      }
+      res.json(speaker);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to fetch speaker' });
+    }
+  },
+
+  async create(req, res) {
+    try {
+      const { name, bio, photoUrl, socialLinks } = req.body;
+      if (!name) {
+        return res.status(400).json({ error: 'Name is required' });
+      }
+      const speaker = await SpeakerModel.createSpeaker({ name, bio, photoUrl, socialLinks });
+      res.status(201).json(speaker);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to create speaker' });
+    }
+  },
+
+  async update(req, res) {
+    try {
+      const { name, bio, photoUrl, socialLinks } = req.body;
+      const speaker = await SpeakerModel.updateSpeaker(req.params.id, { name, bio, photoUrl, socialLinks });
+      if (!speaker) {
+        return res.status(404).json({ error: 'Speaker not found' });
+      }
+      res.json(speaker);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to update speaker' });
+    }
+  },
+
+  async remove(req, res) {
+    try {
+      await SpeakerModel.deleteSpeaker(req.params.id);
+      res.sendStatus(204);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to delete speaker' });
+    }
+  },
+};
+
+module.exports = SpeakerController;

--- a/backend/src/models/speakerModel.js
+++ b/backend/src/models/speakerModel.js
@@ -1,0 +1,35 @@
+const pool = require('../config/db');
+
+const SpeakerModel = {
+  async getAllSpeakers() {
+    const result = await pool.query('SELECT id, name, bio, photo_url, social_links FROM speakers');
+    return result.rows;
+  },
+
+  async getSpeakerById(id) {
+    const result = await pool.query('SELECT id, name, bio, photo_url, social_links FROM speakers WHERE id = $1', [id]);
+    return result.rows[0];
+  },
+
+  async createSpeaker({ name, bio, photoUrl, socialLinks }) {
+    const result = await pool.query(
+      'INSERT INTO speakers (name, bio, photo_url, social_links) VALUES ($1, $2, $3, $4) RETURNING id, name, bio, photo_url, social_links',
+      [name, bio, photoUrl, socialLinks]
+    );
+    return result.rows[0];
+  },
+
+  async updateSpeaker(id, { name, bio, photoUrl, socialLinks }) {
+    const result = await pool.query(
+      'UPDATE speakers SET name = $1, bio = $2, photo_url = $3, social_links = $4 WHERE id = $5 RETURNING id, name, bio, photo_url, social_links',
+      [name, bio, photoUrl, socialLinks, id]
+    );
+    return result.rows[0];
+  },
+
+  async deleteSpeaker(id) {
+    await pool.query('DELETE FROM speakers WHERE id = $1', [id]);
+  },
+};
+
+module.exports = SpeakerModel;

--- a/backend/src/routes/speakerRoutes.js
+++ b/backend/src/routes/speakerRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const SpeakerController = require('../controllers/speakerController');
+const authorizeRoles = require('../middleware/authMiddleware');
+
+router.get('/speakers', SpeakerController.list);
+router.get('/speakers/:id', SpeakerController.getById);
+router.post('/speakers', authorizeRoles('admin'), SpeakerController.create);
+router.put('/speakers/:id', authorizeRoles('admin'), SpeakerController.update);
+router.delete('/speakers/:id', authorizeRoles('admin'), SpeakerController.remove);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add database model for speaker profile
- create speaker controller with CRUD actions
- expose `/api/speakers` routes
- wire speaker routes in the express app
- document the new API endpoints

## Testing
- `npm test` *(fails: Missing script)*
- `(cd backend && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684b071f78288321961bad2dc6ca2b15