### PR TITLE
Add video upload API with SQL schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+backend/uploads

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Additional authentication routes are available:
 - `GET /api/speakers/:id` – fetch a single speaker profile.
 - `PUT /api/speakers/:id` – update a speaker profile (admin only).
 - `DELETE /api/speakers/:id` – remove a speaker profile (admin only).
+- `POST /api/videos` – upload a video file or provide a YouTube/Vimeo URL (speakers and admins).
+- `GET /api/videos` – list uploaded videos.
 
 ### Frontend
 
@@ -59,7 +61,7 @@ The React frontend fetches users from the API and renders them. Run the frontend
 ## Getting Started
 
 1. Install dependencies in both `backend` and `frontend` directories.
-2. Configure PostgreSQL and create a `users` table.
+2. Configure PostgreSQL and create a `users` table. Run `backend/sql/videos.sql` to create the `videos` table.
 3. Start the backend (`npm run dev`) and frontend (`npm start`).
 
 This setup is intentionally minimal and serves as a starting point for further development.

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,8 @@
     "express": "^4.18.0",
     "pg": "^8.10.0",
     "bcrypt": "^6.0.0",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "multer": "^2.0.1"
   },
   "devDependencies": {
     "nodemon": "^2.0.0"

--- a/backend/sql/videos.sql
+++ b/backend/sql/videos.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS videos (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  category TEXT,
+  video_url TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const userRoutes = require('./routes/userRoutes');
 const speakerRoutes = require('./routes/speakerRoutes');
+const videoRoutes = require('./routes/videoRoutes');
 
 const app = express();
 
@@ -8,5 +9,6 @@ app.use(express.json());
 
 app.use('/api', userRoutes);
 app.use('/api', speakerRoutes);
+app.use('/api', videoRoutes);
 
 module.exports = app;

--- a/backend/src/controllers/videoController.js
+++ b/backend/src/controllers/videoController.js
@@ -1,0 +1,43 @@
+const VideoModel = require('../models/videoModel');
+
+const VideoController = {
+  async list(req, res) {
+    try {
+      const videos = await VideoModel.getAllVideos();
+      res.json(videos);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to fetch videos' });
+    }
+  },
+
+  async getById(req, res) {
+    try {
+      const video = await VideoModel.getVideoById(req.params.id);
+      if (!video) {
+        return res.status(404).json({ error: 'Video not found' });
+      }
+      res.json(video);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to fetch video' });
+    }
+  },
+
+  async create(req, res) {
+    try {
+      const { title, description, category, videoUrl } = req.body;
+      const uploaded = req.file ? `/uploads/${req.file.filename}` : videoUrl;
+      if (!title || !uploaded) {
+        return res.status(400).json({ error: 'Title and video are required' });
+      }
+      const video = await VideoModel.createVideo({ title, description, category, videoUrl: uploaded });
+      res.status(201).json(video);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to upload video' });
+    }
+  },
+};
+
+module.exports = VideoController;

--- a/backend/src/models/videoModel.js
+++ b/backend/src/models/videoModel.js
@@ -1,0 +1,23 @@
+const pool = require('../config/db');
+
+const VideoModel = {
+  async getAllVideos() {
+    const result = await pool.query('SELECT id, title, description, category, video_url, created_at FROM videos ORDER BY created_at DESC');
+    return result.rows;
+  },
+
+  async getVideoById(id) {
+    const result = await pool.query('SELECT id, title, description, category, video_url, created_at FROM videos WHERE id = $1', [id]);
+    return result.rows[0];
+  },
+
+  async createVideo({ title, description, category, videoUrl }) {
+    const result = await pool.query(
+      'INSERT INTO videos (title, description, category, video_url) VALUES ($1, $2, $3, $4) RETURNING id, title, description, category, video_url, created_at',
+      [title, description, category, videoUrl]
+    );
+    return result.rows[0];
+  },
+};
+
+module.exports = VideoModel;

--- a/backend/src/routes/videoRoutes.js
+++ b/backend/src/routes/videoRoutes.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const authorizeRoles = require('../middleware/authMiddleware');
+const VideoController = require('../controllers/videoController');
+
+const router = express.Router();
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, path.join(__dirname, '../../uploads'));
+  },
+  filename: (req, file, cb) => {
+    const unique = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, unique + path.extname(file.originalname));
+  },
+});
+
+const upload = multer({ storage });
+
+router.get('/videos', VideoController.list);
+router.get('/videos/:id', VideoController.getById);
+router.post('/videos', authorizeRoles('speaker', 'admin'), upload.single('videoFile'), VideoController.create);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- ignore uploaded files
- add video upload endpoints and models
- use multer for saving uploads
- document new SQL and API usage

## Testing
- `node backend/src/app.js` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bcrypt)*

------
https://chatgpt.com/codex/tasks/task_b_684b07da4ac48321b703cc25d8ef44d5