### PR TITLE
Add admin video approval flow

### DIFF
--- a/backend/sql/videos.sql
+++ b/backend/sql/videos.sql
@@ -4,5 +4,6 @@ CREATE TABLE IF NOT EXISTS videos (
   description TEXT,
   category TEXT,
   video_url TEXT NOT NULL,
+  approved BOOLEAN DEFAULT FALSE,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/backend/src/controllers/videoController.js
+++ b/backend/src/controllers/videoController.js
@@ -11,6 +11,16 @@ const VideoController = {
     }
   },
 
+  async listUnapproved(req, res) {
+    try {
+      const videos = await VideoModel.getUnapprovedVideos();
+      res.json(videos);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to fetch videos' });
+    }
+  },
+
   async getById(req, res) {
     try {
       const video = await VideoModel.getVideoById(req.params.id);
@@ -36,6 +46,20 @@ const VideoController = {
     } catch (err) {
       console.error(err);
       res.status(500).json({ error: 'Failed to upload video' });
+    }
+  },
+
+  async updateApproval(req, res) {
+    try {
+      const { approved } = req.body;
+      const video = await VideoModel.updateApproval(req.params.id, approved);
+      if (!video) {
+        return res.status(404).json({ error: 'Video not found' });
+      }
+      res.json(video);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to update status' });
     }
   },
 };

--- a/backend/src/models/videoModel.js
+++ b/backend/src/models/videoModel.js
@@ -2,20 +2,30 @@ const pool = require('../config/db');
 
 const VideoModel = {
   async getAllVideos() {
-    const result = await pool.query('SELECT id, title, description, category, video_url, created_at FROM videos ORDER BY created_at DESC');
+    const result = await pool.query('SELECT id, title, description, category, video_url, approved, created_at FROM videos ORDER BY created_at DESC');
     return result.rows;
   },
 
   async getVideoById(id) {
-    const result = await pool.query('SELECT id, title, description, category, video_url, created_at FROM videos WHERE id = $1', [id]);
+    const result = await pool.query('SELECT id, title, description, category, video_url, approved, created_at FROM videos WHERE id = $1', [id]);
     return result.rows[0];
   },
 
   async createVideo({ title, description, category, videoUrl }) {
     const result = await pool.query(
-      'INSERT INTO videos (title, description, category, video_url) VALUES ($1, $2, $3, $4) RETURNING id, title, description, category, video_url, created_at',
+      'INSERT INTO videos (title, description, category, video_url) VALUES ($1, $2, $3, $4) RETURNING id, title, description, category, video_url, approved, created_at',
       [title, description, category, videoUrl]
     );
+    return result.rows[0];
+  },
+
+  async getUnapprovedVideos() {
+    const result = await pool.query('SELECT id, title, description, category, video_url, approved, created_at FROM videos WHERE approved = false ORDER BY created_at DESC');
+    return result.rows;
+  },
+
+  async updateApproval(id, approved) {
+    const result = await pool.query('UPDATE videos SET approved = $1 WHERE id = $2 RETURNING id, approved', [approved, id]);
     return result.rows[0];
   },
 };

--- a/backend/src/routes/videoRoutes.js
+++ b/backend/src/routes/videoRoutes.js
@@ -19,7 +19,9 @@ const storage = multer.diskStorage({
 const upload = multer({ storage });
 
 router.get('/videos', VideoController.list);
+router.get('/videos/unapproved', authorizeRoles('admin'), VideoController.listUnapproved);
 router.get('/videos/:id', VideoController.getById);
 router.post('/videos', authorizeRoles('speaker', 'admin'), upload.single('videoFile'), VideoController.create);
+router.patch('/videos/:id/approval', authorizeRoles('admin'), VideoController.updateApproval);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add `approved` column to `videos` table
- list unapproved videos for admin
- allow admins to update approval status

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_684b08e5c0648321b9914a2c0111894c