### PR TITLE
Implement Stripe webhook for subscription updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ DB_NAME=your_db_name
 JWT_SECRET=your_jwt_secret
 STRIPE_PUBLIC_KEY=your_stripe_public_key
 STRIPE_SECRET_KEY=your_stripe_secret_key
+STRIPE_WEBHOOK_SECRET=your_webhook_secret

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Additional authentication routes are available:
 - `DELETE /api/speakers/:id` – remove a speaker profile (admin only).
 - `POST /api/videos` – upload a video file or provide a YouTube/Vimeo URL (speakers and admins).
 - `GET /api/videos` – list uploaded videos.
+- `POST /api/webhook` – Stripe event receiver for subscription updates.
 
 ### Frontend
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,8 +3,12 @@ const userRoutes = require('./routes/userRoutes');
 const speakerRoutes = require('./routes/speakerRoutes');
 const videoRoutes = require('./routes/videoRoutes');
 const paymentRoutes = require('./routes/paymentRoutes');
+const PaymentController = require('./controllers/paymentController');
 
 const app = express();
+
+// Stripe webhook needs the raw body
+app.post('/api/webhook', express.raw({ type: 'application/json' }), PaymentController.webhook);
 
 app.use(express.json());
 


### PR DESCRIPTION
## Summary
- add `STRIPE_WEBHOOK_SECRET` to environment example
- handle Stripe webhook events and update user status
- register webhook route before JSON middleware
- document webhook endpoint in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684b0b8317988321a3e3f4f8517e28b5