### PR TITLE
Add signup/login forms using Axios

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "axios": "^1.6.0"
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import UserList from './components/UserList';
+import SignupForm from './components/SignupForm';
+import LoginForm from './components/LoginForm';
 
 function App() {
   const [users, setUsers] = useState([]);
@@ -14,6 +16,8 @@ function App() {
   return (
     <div>
       <h1>MindLift Users</h1>
+      <SignupForm />
+      <LoginForm />
       <UserList users={users} />
     </div>
   );

--- a/frontend/src/components/LoginForm.js
+++ b/frontend/src/components/LoginForm.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+function LoginForm() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await axios.post('/api/login', { email, password });
+      setMessage(`Login success: ${res.data.token}`);
+    } catch (err) {
+      const msg = err.response?.data?.error || 'Login failed';
+      setMessage(msg);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Log In</h2>
+      <div>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+      </div>
+      <div>
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      <button type="submit">Log In</button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}
+
+export default LoginForm;

--- a/frontend/src/components/SignupForm.js
+++ b/frontend/src/components/SignupForm.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+function SignupForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await axios.post('/api/signup', { name, email, password });
+      setMessage(`Signup success: ${res.data.token}`);
+    } catch (err) {
+      const msg = err.response?.data?.error || 'Signup failed';
+      setMessage(msg);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Sign Up</h2>
+      <div>
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+      <div>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+      </div>
+      <div>
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      <button type="submit">Sign Up</button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}
+
+export default SignupForm;


### PR DESCRIPTION
## Summary
- add signup and login forms to the React frontend
- display the forms in the App component
- include axios in frontend dependencies

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b0caa6b2c8321bffbadf3181c99ca