### PR TITLE
Add ReactPlayer-based video component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "axios": "^1.6.0"
+    "axios": "^1.6.0",
+    "react-player": "^2.12.0"
   }
 }

--- a/frontend/src/components/VideoGrid.js
+++ b/frontend/src/components/VideoGrid.js
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
-import './VideoGrid.css';
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import VideoPlayer from "./VideoPlayer";
+import "./VideoGrid.css";
 
 function VideoGrid() {
   const [videosByCategory, setVideosByCategory] = useState({});
@@ -8,17 +9,17 @@ function VideoGrid() {
   useEffect(() => {
     const fetchVideos = async () => {
       try {
-        const res = await axios.get('/api/videos');
-        const approved = res.data.filter(v => v.approved);
+        const res = await axios.get("/api/videos");
+        const approved = res.data.filter((v) => v.approved);
         const grouped = approved.reduce((acc, video) => {
-          const cat = video.category || 'Uncategorized';
+          const cat = video.category || "Uncategorized";
           if (!acc[cat]) acc[cat] = [];
           acc[cat].push(video);
           return acc;
         }, {});
         setVideosByCategory(grouped);
       } catch (err) {
-        console.error('Failed to fetch videos', err);
+        console.error("Failed to fetch videos", err);
       }
     };
     fetchVideos();
@@ -30,9 +31,9 @@ function VideoGrid() {
         <div key={category}>
           <h3>{category}</h3>
           <div className="video-grid">
-            {videos.map(video => (
+            {videos.map((video) => (
               <div className="video-card" key={video.id}>
-                <video src={video.video_url} controls width="250" />
+                <VideoPlayer url={video.video_url} />
                 <h4>{video.title}</h4>
               </div>
             ))}

--- a/frontend/src/components/VideoPlayer.js
+++ b/frontend/src/components/VideoPlayer.js
@@ -1,0 +1,25 @@
+import React, { useState } from "react";
+import ReactPlayer from "react-player";
+
+function VideoPlayer({ url }) {
+  const [playing, setPlaying] = useState(false);
+
+  return (
+    <div>
+      <ReactPlayer
+        url={url}
+        playing={playing}
+        controls
+        width="100%"
+        height="100%"
+      />
+      <div style={{ marginTop: "8px" }}>
+        <button onClick={() => setPlaying(true)}>Play</button>
+        <button onClick={() => setPlaying(false)}>Pause</button>
+        <button onClick={() => setPlaying(true)}>Resume</button>
+      </div>
+    </div>
+  );
+}
+
+export default VideoPlayer;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "^5.0.1",
-    "stripe": "^18.2.1"
+    "stripe": "^18.2.1",
+    "react-player": "^2.12.0"
   }
 }


### PR DESCRIPTION
## Summary
- integrate `react-player` for embedding videos
- create reusable `VideoPlayer` component
- display videos with the new player in `VideoGrid`
- declare new dependency in package manifests

## Testing
- `npm run build` *(fails: Missing script: "build")*
- `cd frontend && npm run build` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b0f05e0f88321b4eab8102d806473