### PR TITLE
Add admin dashboard with stats

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -4,6 +4,7 @@ const speakerRoutes = require('./routes/speakerRoutes');
 const videoRoutes = require('./routes/videoRoutes');
 const bookmarkRoutes = require('./routes/bookmarkRoutes');
 const paymentRoutes = require('./routes/paymentRoutes');
+const adminRoutes = require('./routes/adminRoutes');
 const PaymentController = require('./controllers/paymentController');
 
 const app = express();
@@ -18,5 +19,6 @@ app.use('/api', speakerRoutes);
 app.use('/api', videoRoutes);
 app.use('/api', bookmarkRoutes);
 app.use('/api', paymentRoutes);
+app.use('/api', adminRoutes);
 
 module.exports = app;

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,0 +1,19 @@
+const StatsModel = require('../models/statsModel');
+
+const AdminController = {
+  async getStats(req, res) {
+    try {
+      const [usersByRole, subscriptionStats, pendingVideos] = await Promise.all([
+        StatsModel.getUserCountByRole(),
+        StatsModel.getSubscriptionStats(),
+        StatsModel.getPendingVideos(),
+      ]);
+      res.json({ usersByRole, subscriptionStats, pendingVideos });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to fetch stats' });
+    }
+  },
+};
+
+module.exports = AdminController;

--- a/backend/src/models/statsModel.js
+++ b/backend/src/models/statsModel.js
@@ -1,0 +1,22 @@
+const pool = require('../config/db');
+
+const StatsModel = {
+  async getUserCountByRole() {
+    const result = await pool.query('SELECT role, COUNT(*) AS count FROM users GROUP BY role');
+    return result.rows;
+  },
+
+  async getSubscriptionStats() {
+    const result = await pool.query('SELECT status, COUNT(*) AS count FROM users GROUP BY status');
+    return result.rows;
+  },
+
+  async getPendingVideos() {
+    const result = await pool.query(
+      'SELECT id, title, description, category, video_url, created_at FROM videos WHERE approved = false ORDER BY created_at DESC'
+    );
+    return result.rows;
+  },
+};
+
+module.exports = StatsModel;

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const AdminController = require('../controllers/adminController');
+const authorizeRoles = require('../middleware/authMiddleware');
+
+router.get('/admin/stats', authorizeRoles('admin'), AdminController.getStats);
+
+module.exports = router;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import SignupForm from './components/SignupForm';
 import LoginForm from './components/LoginForm';
 import VideoGrid from './components/VideoGrid';
 import MyLibrary from './components/MyLibrary';
+import AdminDashboard from './components/AdminDashboard';
 
 function App() {
   const [users, setUsers] = useState([]);
@@ -23,6 +24,7 @@ function App() {
       <UserList users={users} />
       <VideoGrid />
       <MyLibrary />
+      <AdminDashboard />
     </div>
   );
 }

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function AdminDashboard() {
+  const [stats, setStats] = useState(null);
+  const [error, setError] = useState('');
+  const [notAdmin, setNotAdmin] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      setError('No token found');
+      return;
+    }
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      if (payload.role !== 'admin') {
+        setNotAdmin(true);
+        return;
+      }
+    } catch (e) {
+      setError('Invalid token');
+      return;
+    }
+    axios
+      .get('/api/admin/stats', { headers: { Authorization: `Bearer ${token}` } })
+      .then((res) => setStats(res.data))
+      .catch((err) => {
+        setError(err.response?.data?.error || 'Failed to fetch stats');
+      });
+  }, []);
+
+  if (notAdmin) {
+    return <p>Admin access required.</p>;
+  }
+
+  if (error) {
+    return <p>{error}</p>;
+  }
+
+  if (!stats) {
+    return <p>Loading...</p>;
+  }
+
+  return (
+    <div>
+      <h2>Admin Dashboard</h2>
+      <h3>Users by Role</h3>
+      <ul>
+        {stats.usersByRole.map((u) => (
+          <li key={u.role}>{u.role}: {u.count}</li>
+        ))}
+      </ul>
+      <h3>Subscription Status</h3>
+      <ul>
+        {stats.subscriptionStats.map((s) => (
+          <li key={s.status}>{s.status}: {s.count}</li>
+        ))}
+      </ul>
+      <h3>Pending Videos</h3>
+      {stats.pendingVideos.length === 0 ? (
+        <p>No pending videos.</p>
+      ) : (
+        <ul>
+          {stats.pendingVideos.map((v) => (
+            <li key={v.id}>{v.title}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default AdminDashboard;


### PR DESCRIPTION
## Summary
- create stats model and controller for admin dashboard APIs
- expose `/api/admin/stats` route
- display AdminDashboard React component with user and video counts

## Testing
- `node -e "require('./backend/src/app');"` *(fails: MODULE_NOT_FOUND: express)*

------
https://chatgpt.com/codex/tasks/task_b_684b10ee957c83219a19c2c902f853b8