### PR TITLE
Add admin video approval management

### DIFF
--- a/backend/src/controllers/videoController.js
+++ b/backend/src/controllers/videoController.js
@@ -62,6 +62,16 @@ const VideoController = {
       res.status(500).json({ error: 'Failed to update status' });
     }
   },
+
+  async remove(req, res) {
+    try {
+      await VideoModel.deleteVideo(req.params.id);
+      res.sendStatus(204);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Failed to delete video' });
+    }
+  },
 };
 
 module.exports = VideoController;

--- a/backend/src/models/videoModel.js
+++ b/backend/src/models/videoModel.js
@@ -28,6 +28,10 @@ const VideoModel = {
     const result = await pool.query('UPDATE videos SET approved = $1 WHERE id = $2 RETURNING id, approved', [approved, id]);
     return result.rows[0];
   },
+
+  async deleteVideo(id) {
+    await pool.query('DELETE FROM videos WHERE id = $1', [id]);
+  },
 };
 
 module.exports = VideoModel;

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -1,8 +1,19 @@
 const express = require('express');
 const router = express.Router();
 const AdminController = require('../controllers/adminController');
+const VideoController = require('../controllers/videoController');
 const authorizeRoles = require('../middleware/authMiddleware');
 
 router.get('/admin/stats', authorizeRoles('admin'), AdminController.getStats);
+router.patch(
+  '/admin/videos/:id/approval',
+  authorizeRoles('admin'),
+  VideoController.updateApproval,
+);
+router.delete(
+  '/admin/videos/:id',
+  authorizeRoles('admin'),
+  VideoController.remove,
+);
 
 module.exports = router;

--- a/backend/src/routes/videoRoutes.js
+++ b/backend/src/routes/videoRoutes.js
@@ -23,5 +23,6 @@ router.get('/videos/unapproved', authorizeRoles('admin'), VideoController.listUn
 router.get('/videos/:id', VideoController.getById);
 router.post('/videos', authorizeRoles('speaker', 'admin'), upload.single('videoFile'), VideoController.create);
 router.patch('/videos/:id/approval', authorizeRoles('admin'), VideoController.updateApproval);
+router.delete('/videos/:id', authorizeRoles('admin'), VideoController.remove);
 
 module.exports = router;

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -30,6 +30,29 @@ function AdminDashboard() {
       });
   }, []);
 
+  const handleApproval = async (id, approved) => {
+    const token = localStorage.getItem('token');
+    try {
+      if (approved) {
+        await axios.patch(
+          `/api/admin/videos/${id}/approval`,
+          { approved: true },
+          { headers: { Authorization: `Bearer ${token}` } },
+        );
+      } else {
+        await axios.delete(`/api/admin/videos/${id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+      }
+      setStats((prev) => ({
+        ...prev,
+        pendingVideos: prev.pendingVideos.filter((v) => v.id !== id),
+      }));
+    } catch (err) {
+      console.error('Failed to update video status', err);
+    }
+  };
+
   if (notAdmin) {
     return <p>Admin access required.</p>;
   }
@@ -63,7 +86,11 @@ function AdminDashboard() {
       ) : (
         <ul>
           {stats.pendingVideos.map((v) => (
-            <li key={v.id}>{v.title}</li>
+            <li key={v.id}>
+              {v.title}{' '}
+              <button onClick={() => handleApproval(v.id, true)}>Approve</button>{' '}
+              <button onClick={() => handleApproval(v.id, false)}>Reject</button>
+            </li>
           ))}
         </ul>
       )}


### PR DESCRIPTION
## Summary
- add Express routes for admin video approval and deletion
- support deleting videos in the controller/model
- expose delete endpoint in videoRoutes
- show pending videos with Approve/Reject buttons on AdminDashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684b11dc08308321aa716c779f9b7ea3