### PR TITLE
Add Jest tests for login and video upload routes

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "nodemon src/server.js"
+    "dev": "nodemon src/server.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.0",
@@ -17,6 +18,8 @@
     "nodemailer": "^6.9.11"
   },
   "devDependencies": {
-    "nodemon": "^2.0.0"
+    "nodemon": "^2.0.0",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/tests/userRoutes.test.js
+++ b/backend/tests/userRoutes.test.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const app = require('../src/app');
+
+jest.mock('../src/models/userModel');
+jest.mock('bcrypt');
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn(() => 'signed-token'),
+  verify: jest.fn(() => ({ id: 1, role: 'speaker' }))
+}));
+
+const UserModel = require('../src/models/userModel');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+describe('POST /api/login', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns token for valid credentials', async () => {
+    UserModel.findByEmail.mockResolvedValue({ id: 1, password: 'hashed', role: 'speaker' });
+    bcrypt.compare.mockResolvedValue(true);
+
+    const res = await request(app).post('/api/login').send({ email: 'a@b.c', password: 'secret' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBe('signed-token');
+    expect(jwt.sign).toHaveBeenCalled();
+  });
+
+  it('returns 401 for invalid credentials', async () => {
+    UserModel.findByEmail.mockResolvedValue({ id: 1, password: 'hashed', role: 'speaker' });
+    bcrypt.compare.mockResolvedValue(false);
+
+    const res = await request(app).post('/api/login').send({ email: 'a@b.c', password: 'wrong' });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/backend/tests/videoRoutes.test.js
+++ b/backend/tests/videoRoutes.test.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const app = require('../src/app');
+
+jest.mock('../src/models/videoModel');
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn(() => 'signed-token'),
+  verify: jest.fn(() => ({ id: 1, role: 'speaker' }))
+}));
+
+const VideoModel = require('../src/models/videoModel');
+
+describe('POST /api/videos', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a video with videoUrl', async () => {
+    VideoModel.createVideo.mockResolvedValue({ id: 1, title: 'Test' });
+
+    const res = await request(app)
+      .post('/api/videos')
+      .set('Authorization', 'Bearer signed-token')
+      .send({ title: 'Test', videoUrl: 'http://example.com' });
+
+    expect(res.statusCode).toBe(201);
+    expect(VideoModel.createVideo).toHaveBeenCalled();
+  });
+
+  it('returns 400 when title missing', async () => {
+    const res = await request(app)
+      .post('/api/videos')
+      .set('Authorization', 'Bearer signed-token')
+      .send({ videoUrl: 'http://example.com' });
+
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest as a dev dependency and provide a test script
- configure Jest for the backend
- add unit tests for user login
- add unit tests for video upload

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b138ad708832186577955039eaf43