### PR TITLE
Disable Stripe to make subscriptions free

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,11 @@ DB_USER=your_db_user
 DB_PASSWORD=your_db_password
 DB_NAME=your_db_name
 JWT_SECRET=your_jwt_secret
-STRIPE_PUBLIC_KEY=your_stripe_public_key
-STRIPE_SECRET_KEY=your_stripe_secret_key
-STRIPE_WEBHOOK_SECRET=your_webhook_secret
+# Stripe integration is disabled by default. Uncomment and provide these values
+# if you decide to re-enable paid subscriptions.
+#STRIPE_PUBLIC_KEY=your_stripe_public_key
+#STRIPE_SECRET_KEY=your_stripe_secret_key
+#STRIPE_WEBHOOK_SECRET=your_webhook_secret
 EMAIL_HOST=smtp.example.com
 EMAIL_PORT=587
 EMAIL_USER=your_email_user

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The configuration loader in `config.js` reads these variables securely and expos
 
 The `.env` file now includes settings for the email server used by NodeMailer. Set `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USER`, `EMAIL_PASS`, and `EMAIL_FROM` to enable subscription confirmation emails.
 
+Stripe integration has been disabled so everyone can subscribe for free. The `/api/subscribe` endpoint simply marks a user as paid without processing a payment.
+
 ## Running the Example
 
 To see the configuration loader in action, run:
@@ -55,7 +57,7 @@ Additional authentication routes are available:
 - `DELETE /api/speakers/:id` – remove a speaker profile (admin only).
 - `POST /api/videos` – upload a video file or provide a YouTube/Vimeo URL (speakers and admins).
 - `GET /api/videos` – list uploaded videos.
-- `POST /api/webhook` – Stripe event receiver for subscription updates.
+- `POST /api/webhook` – placeholder endpoint (Stripe temporarily disabled).
 
 ### Frontend
 

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -1,4 +1,3 @@
-const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY || '');
 const UserModel = require('../models/userModel');
 const mailer = require('../config/mailer');
 
@@ -10,67 +9,31 @@ const PaymentController = {
         return res.status(400).json({ error: 'userId is required' });
       }
 
-      const intent = await stripe.paymentIntents.create({
-        amount: 1000,
-        currency: 'usd',
-        description: 'Monthly subscription',
-        automatic_payment_methods: { enabled: true },
-        metadata: { userId },
-      });
+      // Immediately mark the user as paid since subscriptions are free
+      await UserModel.updateStatus(userId, 'paid');
+      const user = await UserModel.findById(userId);
+      if (user && user.email) {
+        try {
+          await mailer.sendMail({
+            from: process.env.EMAIL_FROM || process.env.EMAIL_USER,
+            to: user.email,
+            subject: 'Subscription Confirmed',
+            text: 'Your subscription is active. Thank you for choosing MindLift!',
+          });
+        } catch (emailErr) {
+          console.error('Failed to send confirmation email:', emailErr);
+        }
+      }
 
-      res.json({ clientSecret: intent.client_secret });
+      res.json({ message: 'Subscription activated without payment.' });
     } catch (err) {
       console.error(err);
-      res.status(500).json({ error: 'Failed to initiate payment' });
+      res.status(500).json({ error: 'Failed to activate subscription' });
     }
   },
 
   async webhook(req, res) {
-    const sig = req.headers['stripe-signature'];
-    let event;
-
-    try {
-      event = stripe.webhooks.constructEvent(
-        req.body,
-        sig,
-        process.env.STRIPE_WEBHOOK_SECRET || ''
-      );
-    } catch (err) {
-      console.error('Webhook signature verification failed.', err.message);
-      return res.status(400).send(`Webhook Error: ${err.message}`);
-    }
-
-    const intent = event.data.object;
-    const userId = intent.metadata && intent.metadata.userId;
-
-    try {
-      if (event.type === 'payment_intent.succeeded') {
-        if (userId) {
-          await UserModel.updateStatus(userId, 'paid');
-          const user = await UserModel.findById(userId);
-          if (user && user.email) {
-            try {
-              await mailer.sendMail({
-                from: process.env.EMAIL_FROM || process.env.EMAIL_USER,
-                to: user.email,
-                subject: 'Subscription Confirmed',
-                text: 'Your subscription is active. Thank you for choosing MindLift!',
-              });
-            } catch (emailErr) {
-              console.error('Failed to send confirmation email:', emailErr);
-            }
-          }
-        }
-      } else if (event.type === 'payment_intent.payment_failed') {
-        if (userId) {
-          await UserModel.updateStatus(userId, 'unpaid');
-        }
-      }
-    } catch (err) {
-      console.error('Failed to update user status:', err);
-      return res.status(500).end();
-    }
-
+    // Stripe is disabled, but keep the endpoint for compatibility
     res.json({ received: true });
   },
 };

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -9,7 +9,7 @@ const UserModel = {
   async createUser({ name, email, password, role }) {
     const result = await pool.query(
       'INSERT INTO users (name, email, password, role, status) VALUES ($1, $2, $3, $4, $5) RETURNING id, name, email, role, status',
-      [name, email, password, role, 'unpaid']
+      [name, email, password, role, 'paid']
     );
     return result.rows[0];
   },

--- a/config.js
+++ b/config.js
@@ -25,6 +25,10 @@ function getEnv(name) {
   return process.env[name];
 }
 
+function getEnvOptional(name, defaultValue = '') {
+  return process.env[name] || defaultValue;
+}
+
 module.exports = {
   db: {
     host: getEnv('DB_HOST'),
@@ -35,7 +39,7 @@ module.exports = {
   },
   jwtSecret: getEnv('JWT_SECRET'),
   stripe: {
-    publicKey: getEnv('STRIPE_PUBLIC_KEY'),
-    secretKey: getEnv('STRIPE_SECRET_KEY'),
+    publicKey: getEnvOptional('STRIPE_PUBLIC_KEY'),
+    secretKey: getEnvOptional('STRIPE_SECRET_KEY'),
   },
 };


### PR DESCRIPTION
## Summary
- mark new users as `paid` by default
- bypass Stripe in the payment controller
- make Stripe config optional
- comment Stripe variables in `.env.example`
- note that Stripe is disabled in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b1ab246408321a71a142a029168fb